### PR TITLE
Add Dockerfile and CI for building and publishing Docker image

### DIFF
--- a/.github/workflows/build-test-lint.yml
+++ b/.github/workflows/build-test-lint.yml
@@ -1,0 +1,31 @@
+name: Build, Test, and Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-test-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.24
+
+      - name: Compile the code
+        run: go build -v ./...
+
+      - name: Run tests
+        run: go test -v ./...
+
+      - name: Lint the code
+        run: golangci-lint run

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,76 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compile the code
+        run: go build -v ./...
+
+      - name: Run tests
+        run: go test -v ./...
+
+      - name: Lint the code
+        run: golangci-lint run
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: false
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.sha }}
+            ghcr.io/${{ github.repository }}:latest
+
+  publish:
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.sha }}
+            ghcr.io/${{ github.repository }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Use the official Go image as the base image
+FROM golang:1.24 as builder
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Copy the Go module files and download dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the rest of the application code
+COPY . .
+
+# Build the Go application
+RUN go build -o ekz-tesla .
+
+# Use a minimal base image for the final image
+FROM scratch
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Copy the built Go application from the builder stage
+COPY --from=builder /app/ekz-tesla .
+
+# Set the entry point to the executable
+ENTRYPOINT ["./ekz-tesla"]


### PR DESCRIPTION
Add Dockerfile and GitHub Actions workflows to build, test, lint, and publish Docker image.

* **Dockerfile**
  - Use the official Go image as the base image.
  - Set the working directory to `/app`.
  - Copy Go module files and download dependencies.
  - Copy the rest of the application code.
  - Build the Go application and set the entry point to the executable.

* **GitHub Actions Workflow for Docker Image**
  - Define a workflow triggered on push and pull request events to the `main` branch.
  - Set up jobs to build and publish the Docker image.
  - Compile the code, run tests, and lint the code.
  - Build the Docker image and tag it with the commit SHA and `latest`.
  - Publish the Docker image to GitHub Container Registry only on the `main` branch.

* **GitHub Actions Workflow for Build, Test, and Lint**
  - Define a workflow triggered on all push and pull request events.
  - Set up a job to build, test, and lint the code.
  - Compile the code, run tests, and lint the code.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/denysvitali/ekz-tesla/pull/1?shareId=23a32d01-8c4d-4e5e-889a-b87ccec06e0c).